### PR TITLE
SAAS-3479: fix shellcheck SC2316 in utils.sh

### DIFF
--- a/src/scripts/utils.sh
+++ b/src/scripts/utils.sh
@@ -22,5 +22,6 @@ detect_os() {
       ;;
   esac
 
-  export readonly PLATFORM
+  readonly PLATFORM
+  export PLATFORM
 }


### PR DESCRIPTION
## Summary

Fix shellcheck SC2316 in `src/scripts/utils.sh`. Unblocks CI on renovate PRs #4, #5, #6, #7 (all of which hit this on every shellcheck run).

## What was wrong

```bash
export readonly PLATFORM
```

This does NOT make `PLATFORM` readonly. It applies `export` to a variable literally named `readonly`. Shellcheck flags it as SC2316.

## Fix

Split into two statements:

```bash
readonly PLATFORM
export PLATFORM
```

## Test plan

- [ ] After merge, #4–#7 should re-run CI and pass shellcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)