### PR TITLE
SAAS-3479: override Renovate schedule to run daily on this repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>MuniBillingLLC/renovate-config"
-  ]
+  ],
+  "schedule": ["at any time"]
 }


### PR DESCRIPTION
The shared preset (local>MuniBillingLLC/renovate-config, default.json) restricts Renovate write actions to Saturdays and Sundays. That means checkbox-triggered rebases (like the one ticked on PR #5) don't get honored until the weekend, which made an interactive CircleCI orb bump sit in CONFLICTING state for days with no way to nudge it forward.

Override the schedule at the repo level so Renovate can rebase, open, and close PRs any day of the week. This is scoped to msteams-circleci-orb only — the org-wide weekend schedule stays intact for other repos.